### PR TITLE
Добавил менеджер катсцен

### DIFF
--- a/Assets/Project/Resources/Prefabs/Initializers/GameplayEntryPoint.prefab
+++ b/Assets/Project/Resources/Prefabs/Initializers/GameplayEntryPoint.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9901fc1978007da7aef3889363c7728a9fa3559cb0e3917c0650bf44156b6cb6
-size 2454
+oid sha256:8fc1ddc91e6f989a732cb933b02d9cc34dbdaaa2d7f68a68a4425a09b42d817b
+size 2542

--- a/Assets/Project/ScriptableObjects/Configs/CutscenesConfig.asset
+++ b/Assets/Project/ScriptableObjects/Configs/CutscenesConfig.asset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:117beb479f67b67f9f20ccad2cb2a650d03de869a77bd110b311d7a2be5a6653
+size 704

--- a/Assets/Project/ScriptableObjects/Configs/CutscenesConfig.asset.meta
+++ b/Assets/Project/ScriptableObjects/Configs/CutscenesConfig.asset.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c0cb7d08a91bb6e76dcef693664cad5a3eb81d5e163eed9941153720f6fee12
+size 189

--- a/Assets/Project/Scripts/Initializers/GameplayEntryPoint.cs
+++ b/Assets/Project/Scripts/Initializers/GameplayEntryPoint.cs
@@ -1,25 +1,27 @@
+using BigProject.Intercatable.HighlightedObjects;
 using BigProject.Managers;
+using BigProject.Managers.CursorManager;
 using BigProject.Player;
 using BigProject.Settings;
 using BigProject.Systems;
+using BigProject.Managers.CutsceneManager;
 using BigProject.Systems.HUD;
 using BigProject.Systems.Inventory;
 using BigProject.Systems.Inventory.ItemsModifiers;
+using BigProject.Systems.QuestSystem;
 using BigProject.UI;
-using BigProject.UI.Dialogue;
 using BigProject.UI.Common;
+using BigProject.UI.Dialogue;
 using BigProject.UI.Replica;
 using BigProject.Utilities;
 using System;
-using UnityEngine;
-using UnityEngine.Assertions;
-using BigProject.Systems.QuestSystem;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 using UnityEngine.AI;
+using UnityEngine.Assertions;
+using UnityEngine.Playables;
 using UnityEngine.SceneManagement;
-using BigProject.Managers.CursorManager;
-using BigProject.Intercatable.HighlightedObjects;
 
 namespace BigProject.Initializers
 {
@@ -50,6 +52,8 @@ namespace BigProject.Initializers
         private PlayerController _playerControllerPrefab;
         [SerializeField]
         private GameObject _cursorManagerPrefab;
+        [SerializeField]
+        private CutscenesConfig _cutscenesConfig;
 
         [field: SerializeField]
         public Scenes _sceneToLoad; // For feature load progress
@@ -71,6 +75,7 @@ namespace BigProject.Initializers
         private List<QuestSwitch> _questsSwitches = new();
         private QuestsBoundariesTracker _questsTracker;
         private PlayerSpawner _playerSpawner;
+        private CutsceneManager _cutsceneManager;
 
         private static bool _isInstantiated;
 
@@ -96,6 +101,9 @@ namespace BigProject.Initializers
             Assert.IsNotNull(_journalConfig, String.Format(LogStr.CRITICAL_NOT_SERIALIZED_FIELD, "Gameplay Entry Point", "Journal Config"));
             Assert.IsNotNull(_questSwitchConfig, String.Format(LogStr.CRITICAL_NOT_SERIALIZED_FIELD, "Gameplay Entry Point", "QuestSwitchConfig"));
             Assert.IsNotNull(_questTrackerConfig, String.Format(LogStr.CRITICAL_NOT_SERIALIZED_FIELD, "Gameplay Entry Point", "QuestTrackerConfig"));
+            Assert.IsNotNull(_playerControllerPrefab, String.Format(LogStr.CRITICAL_NOT_SERIALIZED_FIELD, "Gameplay Entry Point", "PlayerController Prefab"));
+            Assert.IsNotNull(_cursorManagerPrefab, String.Format(LogStr.CRITICAL_NOT_SERIALIZED_FIELD, "Gameplay Entry Point", "CursorManager Prefab"));
+            Assert.IsNotNull(_cutscenesConfig, String.Format(LogStr.CRITICAL_NOT_SERIALIZED_FIELD, "Gameplay Entry Point", "CutscenesConfig"));
 
             GameObject gameplayServices = new GameObject("GameplayServices");
             transform.parent = gameplayServices.transform; // For dispose after gameplay exit
@@ -133,8 +141,10 @@ namespace BigProject.Initializers
             InitHUD();
             _questJournal.Init();
             AddQuestsSwitches(progressManager);
-            CreatePlayer();
-            CreateCursorManager();
+            SceneLoadManager sceneLoader = ServiceLocator.GetService<SceneLoadManager>();
+            CreatePlayer(sceneLoader);
+            CreateCursorManager(sceneLoader);
+            CreateCutsceneManager(sceneLoader);
             GameLogManager.Info(LogStr.INFO_INITIALIZING_GAMEPLAY_SERVICES_COMPLETED);
         }
 
@@ -217,10 +227,9 @@ namespace BigProject.Initializers
             }
         }
 
-        private void CreatePlayer()
+        private void CreatePlayer(SceneLoadManager sceneLoader)
         {
             PlayerController playerController = Instantiate(_playerControllerPrefab);
-            SceneLoadManager sceneLoader = ServiceLocator.GetService<SceneLoadManager>();
             playerController.Init(_playerInput, sceneLoader);
             playerController.transform.parent = transform.parent;
             ServiceLocator.AddService(playerController);
@@ -235,7 +244,7 @@ namespace BigProject.Initializers
             }
         }
 
-        private void CreateCursorManager()
+        private void CreateCursorManager(SceneLoadManager sceneLoader)
         {
             GameObject cursorManagerObject = Instantiate(_cursorManagerPrefab, transform.parent);
             CursorManager cursorManager = cursorManagerObject.GetComponent<CursorManager>();
@@ -248,13 +257,28 @@ namespace BigProject.Initializers
                 return;
             }
 
-            highlighter.Init(ServiceLocator.GetService<SceneLoadManager>(), cursorManager);
+            highlighter.Init(sceneLoader, cursorManager);
             cursorManagerObject.SetActive(true);
 
             // For case when run from gameplay scene.
             if (!string.Equals(Scenes.MainMenu.ToString(), SceneManager.GetActiveScene().name))
             {
                 highlighter.RestartChecking();
+            }
+        }
+
+        private void CreateCutsceneManager(SceneLoadManager sceneLoader)
+        {
+            GameObject cutsceneManagerObject = new("CutsceneManager");
+            cutsceneManagerObject.transform.SetParent(transform.parent);
+            PlayableDirector director = cutsceneManagerObject.AddComponent<PlayableDirector>();
+            _cutsceneManager = new(director, sceneLoader, _cutscenesConfig);
+            ServiceLocator.AddService(_cutsceneManager);
+
+            // For case when run from gameplay scene.
+            if (!string.Equals(Scenes.MainMenu.ToString(), SceneManager.GetActiveScene().name))
+            {
+                _cutsceneManager.FindActors();
             }
         }
 
@@ -293,6 +317,7 @@ namespace BigProject.Initializers
 
             _questsTracker?.Dispose();
             _playerSpawner?.Dispose();
+            _cutsceneManager?.Dispose();
             Destroy(transform.parent.gameObject);
         }
     }

--- a/Assets/Project/Scripts/Managers/CutsceneManager.meta
+++ b/Assets/Project/Scripts/Managers/CutsceneManager.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d07e6ea1fd7e3f927ba04c69f5c2341413757ea3752f5f5877a74d3ac3e01fc
+size 172

--- a/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneActor.cs
+++ b/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneActor.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace BigProject.Managers.CutsceneManager
+{
+    public class CutsceneActor : MonoBehaviour
+    {
+        [field: SerializeField]
+        public string Name { get; private set; }
+    }
+}

--- a/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneActor.cs.meta
+++ b/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneActor.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9902119eaf70bc64d71e540812bf091e206304ea131386291acd2934db7d78eb
+size 59

--- a/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneManager.cs
+++ b/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneManager.cs
@@ -1,0 +1,232 @@
+using BigProject.Settings;
+using BigProject.Systems;
+using BigProject.Utilities;
+using System;
+using System.Collections.Generic;
+using Unity.Cinemachine;
+using UnityEngine;
+using UnityEngine.Playables;
+using UnityEngine.Timeline;
+
+namespace BigProject.Managers.CutsceneManager
+{
+    public class CutsceneManager : IDisposable
+    {
+        private PlayableDirector _director;
+        private SceneLoadManager _sceneLoader;
+        private CutscenesConfig _config;
+        private Dictionary<string, CutsceneActor> _actors = new();
+        private GameObject _cutscenePrefabs;
+
+        public bool IsPlaying { get; private set; } = false;
+
+        public CutsceneManager(PlayableDirector director, SceneLoadManager sceneLoader, CutscenesConfig config)
+        {
+            _director = director;
+            _sceneLoader = sceneLoader;
+            _config = config;
+            ExceptionUtilities.ThrowIfNull(_director, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "PlayableDirector"));
+            ExceptionUtilities.ThrowIfNull(_sceneLoader, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "SceneLoadManager"));
+            ExceptionUtilities.ThrowIfNull(_config, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "CutsceneConfig"));
+            _director.stopped += Stop;
+            _sceneLoader.SceneLoadingStarted += ClearActors;
+            _sceneLoader.SceneLoadingCompleted += FindActors;
+        }
+
+        public void Play(TimelineAsset timeline)
+        {
+            ExceptionUtilities.ThrowIfNull(timeline, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "TimelineAsset"));
+
+            if (IsPlaying)
+            {
+                Debug.LogWarning(string.Format(LogStr.WARNING_SYSTEM, $"CutsceneManager", $"unable to play {timeline.name}, already playing clip"));
+                return;
+            }
+
+            IsPlaying = true;
+            GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"start playing {timeline.name}"));
+            _director.playableAsset = timeline;
+            AddCutscenePrefabs(timeline);
+            InitTimeline(timeline);
+            _director.Play();
+        }
+
+        /// <summary>
+        /// For interrupt.
+        /// </summary>
+        public void Stop()
+        {
+            if (IsPlaying)
+            {
+                _director.Stop();
+            }
+        }
+
+        public void Dispose()
+        {
+            _director.stopped -= Stop;
+            _sceneLoader.SceneLoadingStarted -= ClearActors;
+            _sceneLoader.SceneLoadingCompleted -= FindActors;
+        }
+
+        /// <summary>
+        /// Automatically called when scene load complete.
+        /// </summary>
+        public void FindActors()
+        {
+            ClearActors();
+            GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"searching new actors..."));
+            AddActors(GameObject.FindObjectsByType<CutsceneActor>(FindObjectsSortMode.None));
+        }
+
+        private void ClearActors()
+        {
+            Stop();
+            _actors.Clear();
+        }
+
+        private void InitTimeline(TimelineAsset timeline)
+        {
+            GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"start timeline initializing..."));
+
+            foreach (TrackAsset track in timeline.GetOutputTracks())
+            {
+                // CinemachineTrack has actors inside.
+                if (!_actors.TryGetValue(track.name, out CutsceneActor actor) && track is not CinemachineTrack)
+                {
+                    Debug.LogWarning(string.Format(LogStr.WARNING_SYSTEM, $"CutsceneManager", $"unable to get actor {track.name}"));
+                    continue;
+                }
+
+                switch (track)
+                {
+                    case AnimationTrack:
+                        Animator animator = actor.GetComponent<Animator>();
+                        ExceptionUtilities.ThrowIfNull(animator, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "Actor AnimationTrack"));
+                        _director.SetGenericBinding(track, animator);
+                        break;
+                    case ActivationTrack:
+                        _director.SetGenericBinding(track, actor.gameObject);
+                        break;
+                    case CinemachineTrack cinemachineTrack:
+                        CinemachineBrain brain = Camera.main.GetComponent<CinemachineBrain>();
+                        ExceptionUtilities.ThrowIfNull(brain, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "Actor CinemachineBrain"));
+                        _director.SetGenericBinding(track, brain);
+
+                        // Cameras shots inside.
+                        InitCameras(cinemachineTrack);
+                        break;
+                    case AudioTrack:
+                        AudioSource audioSource = actor.GetComponent<AudioSource>();
+                        ExceptionUtilities.ThrowIfNull(audioSource, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "Actor AudioSource"));
+                        _director.SetGenericBinding(track, audioSource);
+                        break;
+                    case SignalTrack:
+                        SignalReceiver signalReceiver = actor.GetComponent<SignalReceiver>();
+                        ExceptionUtilities.ThrowIfNull(signalReceiver, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", "Actor SignalReceiver"));
+                        _director.SetGenericBinding(track, signalReceiver);
+                        break;
+                    default:
+                        Debug.LogWarning(string.Format(LogStr.WARNING_SYSTEM, $"CutsceneManager", $"unknown actor type {track.GetType()}"));
+                        break;
+                }
+            }
+        }
+
+        private void InitCameras(CinemachineTrack cinemachineTrack)
+        {
+            GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"start {cinemachineTrack.name} cameras initializing..."));
+
+            foreach (TimelineClip clip in cinemachineTrack.GetClips())
+            {
+                CinemachineShot shot = clip.asset as CinemachineShot;
+
+                if (!_actors.TryGetValue(clip.displayName, out CutsceneActor cameraActor))
+                {
+                    Debug.LogWarning(string.Format(LogStr.WARNING_SYSTEM, $"CutsceneManager", $"unable to find camera actor {clip.displayName}"));
+                    continue;
+                }
+
+                CinemachineCamera camera = cameraActor.GetComponent<CinemachineCamera>();
+                ExceptionUtilities.ThrowIfNull(camera, string.Format(LogStr.CRITICAL_NULL_REFERENCE, "CutsceneManager", $"camera actor {clip.displayName}"));
+                GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"add {clip.displayName} camera"));
+                _director.SetReferenceValue(shot.VirtualCamera.exposedName, camera);
+
+                string targetActorName = cameraActor.Name.Replace(_config.CameraActorPrefix, "");
+
+                if (_actors.TryGetValue(targetActorName, out CutsceneActor targetActor))
+                {
+                    GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"add {targetActorName} as camera target"));
+                    camera.Follow = targetActor.transform;
+                }
+                else
+                {
+                    GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"no target {targetActorName} for camera"));
+                }
+            }
+        }
+
+        private void AddCutscenePrefabs(TimelineAsset timeline)
+        {
+            if (_config.TryGetCutscenePrefabs(timeline, out List<GameObject> prefabs))
+            {
+                _cutscenePrefabs = new GameObject($"Cutscene_{timeline.name}_prefabs");
+
+                foreach (GameObject prefab in prefabs)
+                {
+                    GameObject.Instantiate(prefab, _cutscenePrefabs.transform);
+                }
+
+                AddPrefabsActors();
+            }
+        }
+
+        private void AddPrefabsActors() => AddActors(_cutscenePrefabs.GetComponentsInChildren<CutsceneActor>());
+
+        private void RemovePrefabsActors() => RemoveActors(_cutscenePrefabs.GetComponentsInChildren<CutsceneActor>());
+
+        private void AddActors(CutsceneActor[] actorsArray)
+        {
+            if (actorsArray == null)
+            {
+                return;
+            }
+
+            foreach (CutsceneActor actor in actorsArray)
+            {
+                if (_actors.TryAdd(actor.Name, actor))
+                {
+                    GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"add actor {actor.name}"));
+                }
+                else
+                {
+                    Debug.LogWarning(string.Format(LogStr.WARNING_SYSTEM, $"CutsceneManager", $"try add duplicate actor {actor.name}"));
+                }
+            }
+        }
+
+        private void RemoveActors(CutsceneActor[] actorsArray)
+        {
+            if (actorsArray == null)
+            {
+                return;
+            }
+
+            foreach (CutsceneActor actor in actorsArray)
+            {
+                GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"remove actor {actor.name}"));
+                _actors.Remove(actor.Name);
+            }
+        }
+
+        private void Stop(PlayableDirector _)
+        {
+            GameLogManager.Info(string.Format(LogStr.INFO_SYSTEM, $"CutsceneManager", $"stop playing"));
+            _director.playableAsset = null;
+            RemovePrefabsActors();
+            GameObject.Destroy(_cutscenePrefabs);
+            _cutscenePrefabs = null;
+            IsPlaying = false;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneManager.cs.meta
+++ b/Assets/Project/Scripts/Managers/CutsceneManager/CutsceneManager.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9ff4095aba2bfe2b3d3c9f68786e2c3b3cd37149626e5036f1810576eff07c0
+size 59

--- a/Assets/Project/Scripts/Managers/GameplayManager/GameplayManager.cs
+++ b/Assets/Project/Scripts/Managers/GameplayManager/GameplayManager.cs
@@ -14,7 +14,8 @@ namespace BigProject.Managers
         MiniGame,
         Map,
         Inventory,
-        Pause
+        Pause,
+        Cutscene
     }
 
     /// <summary>
@@ -44,7 +45,7 @@ namespace BigProject.Managers
         /// <param name="id">Queue id</param>
         public void AddQueueToState(GameplayState state, int id)
         {
-            if (_tickQueueIds.TryGetValue(state, out var stateIds))
+            if (_tickQueueIds.TryGetValue(state, out List<int> stateIds))
             {
                 stateIds.Add(id);
             }
@@ -80,7 +81,7 @@ namespace BigProject.Managers
             _state = state;
             StateChanged?.Invoke(_state);
 
-            if (_tickQueueIds.TryGetValue(_state, out var nextIds))
+            if (_tickQueueIds.TryGetValue(_state, out List<int> nextIds))
             {
                 foreach (int id in nextIds)
                 {

--- a/Assets/Project/Scripts/Settings/CutscenesConfig.cs
+++ b/Assets/Project/Scripts/Settings/CutscenesConfig.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Timeline;
+
+namespace BigProject.Settings
+{
+    [CreateAssetMenu(fileName = "CutscenesConfig", menuName = "Scriptable Objects/Configs/CutscenesConfig")]
+    public class CutscenesConfig : ScriptableObject
+    {
+        [field: SerializeField]
+        public string CameraActorPrefix { get; private set; }
+
+        [Serializable]
+        private class CutsceneSettings
+        {
+            public TimelineAsset timeline;
+            public List<GameObject> prefabs;
+        }
+
+        [SerializeField]
+        private List<CutsceneSettings> _cutscenesSettings;
+
+        public bool TryGetCutscenePrefabs(TimelineAsset timeline, out List<GameObject> prefabs)
+        {
+            CutsceneSettings cutsceneSettings = _cutscenesSettings.First(x =>  x.timeline == timeline);
+            prefabs = cutsceneSettings != null ? cutsceneSettings.prefabs : null;
+            return prefabs != null;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Settings/CutscenesConfig.cs.meta
+++ b/Assets/Project/Scripts/Settings/CutscenesConfig.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:886bf4fc0649d58f3a29cd62c6b90aa7e354e443960cd67639aa254f1f0d7901
+size 59

--- a/Assets/Project/Scripts/Utilities/GameplayStatesHandler.cs
+++ b/Assets/Project/Scripts/Utilities/GameplayStatesHandler.cs
@@ -48,6 +48,7 @@ namespace BigProject.Utilities
                     _input.SwitchToMiniGameActionMap();
                     break;
                 case GameplayState.Dialogue:
+                case GameplayState.Cutscene:
                     _hud.HideWidget(_hudConfig.HUDInventoryWidgetId);
                     _input.SwitchToMiniGameActionMap();
                     break;


### PR DESCRIPTION
CutsceneManager 
- проигрывает заданный таймлайн, предварительно подгрузив связанные с ним префабы.
- В таймлайн протягивает всех акторов - из префабов и на сцене.
- Таким образом, можно создавать ассеты таймлайнов и юзать на любой сцене, проставив акторов.
- Для виртуальных камер brain от Camera.main + сами камеры также через акторов на сцене ищутся.

CutsceneActor
- Хранит имя актора (ключ)

Дороги (track) в таймлайне по имени должны соответствовать имени актора. Через имя и производится поиск.